### PR TITLE
Add admission policy endpoint and type

### DIFF
--- a/policy/admission.go
+++ b/policy/admission.go
@@ -1,0 +1,37 @@
+package policy
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/paloaltonetworks/prisma-cloud-compute-go/pcc"
+)
+
+const AdmissionEndpoint = "api/v1/policies/admission"
+
+type AdmissionPolicy struct {
+	Id    string          `json:"_id,omitempty"`
+	Rules []AdmissionRule `json:"rules,omitempty"`
+}
+
+type AdmissionRule struct {
+	Description string `json:"description,omitempty"`
+	Disabled    bool   `json:"disabled"`
+	Effect      string `json:"effect,omitempty"`
+	Name        string `json:"name,omitempty"`
+	Script      string `json:"script,omitempty"`
+}
+
+// Get the current host admission policy.
+func GetAdmission(c pcc.Client) (AdmissionPolicy, error) {
+	var ans AdmissionPolicy
+	if err := c.Request(http.MethodGet, AdmissionEndpoint, nil, nil, &ans); err != nil {
+		return ans, fmt.Errorf("error getting admission policy: %s", err)
+	}
+	return ans, nil
+}
+
+// Update the current host admission policy.
+func UpdateAdmission(c pcc.Client, policy AdmissionPolicy) error {
+	return c.Request(http.MethodPut, AdmissionEndpoint, nil, policy, nil)
+}


### PR DESCRIPTION
## Description

Fix #25 which is requirement for https://github.com/PaloAltoNetworks/terraform-provider-prismacloudcompute/issues/32

## Motivation and Context

Add ability to manage admission controller rules through Terraform

## How Has This Been Tested?

Using Prisma Cloud Compute 21.08

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
