### PR TITLE
Add API to manipulate custom rules

### DIFF
--- a/rule/custom_rule.go
+++ b/rule/custom_rule.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math/rand"
 	"net/http"
+	"time"
 
 	"github.com/paloaltonetworks/prisma-cloud-compute-go/pcc"
 )
@@ -12,11 +13,11 @@ const CustomRulesEndpoint = "api/v1/custom-rules"
 
 type CustomRule struct {
 	Description string   `json:"description,omitempty"`
-	Id          []string `json:"_id,omitempty"`
-	Message     []string `json:"message,omitempty"`
+	Id          int `json:"_id,omitempty"`
+	Message     string `json:"message,omitempty"`
 	Name        string   `json:"name,omitempty"`
-	Script      []string `json:"script,omitempty"`
-	Type        []string `json:"type,omitempty"`
+	Script      string `json:"script,omitempty"`
+	Type        string `json:"type,omitempty"`
 }
 
 // Get all custom rules.
@@ -39,14 +40,14 @@ func GetCustomRule(c pcc.Client, id int) (*CustomRule, error) {
 			return &val, nil
 		}
 	}
-	return nil, fmt.Errorf("custom rule '%s' not found", name)
+	return nil, fmt.Errorf("custom rule '%d' not found", id)
 }
 
 // Create a new custom rule.
 func CreateCustomRule(c pcc.Client, rule CustomRule) error {
 	id, err := GenerateCustomRuleId(c)
 	if err != nil {
-		return nil, fmt.Errorf("error getting custom rules '%d': %s", id, err)
+		return fmt.Errorf("error getting custom rules '%d': %s", id, err)
 	}
 	rule.Id = id
 	return UpdateCustomRule(c, rule)

--- a/rule/custom_rule.go
+++ b/rule/custom_rule.go
@@ -12,10 +12,10 @@ import (
 const CustomRulesEndpoint = "api/v1/custom-rules"
 
 type CustomRule struct {
-	Description string   `json:"description,omitempty"`
-	Id          int `json:"_id,omitempty"`
+	Description string `json:"description,omitempty"`
+	Id          int    `json:"_id,omitempty"`
 	Message     string `json:"message,omitempty"`
-	Name        string   `json:"name,omitempty"`
+	Name        string `json:"name,omitempty"`
 	Script      string `json:"script,omitempty"`
 	Type        string `json:"type,omitempty"`
 }

--- a/rule/custom_rule.go
+++ b/rule/custom_rule.go
@@ -1,0 +1,85 @@
+package rule
+
+import (
+	"fmt"
+	"math/rand"
+	"net/http"
+
+	"github.com/paloaltonetworks/prisma-cloud-compute-go/pcc"
+)
+
+const CustomRulesEndpoint = "api/v1/custom-rules"
+
+type CustomRule struct {
+	Description string   `json:"description,omitempty"`
+	Id          []string `json:"_id,omitempty"`
+	Message     []string `json:"message,omitempty"`
+	Name        string   `json:"name,omitempty"`
+	Script      []string `json:"script,omitempty"`
+	Type        []string `json:"type,omitempty"`
+}
+
+// Get all custom rules.
+func ListCustomRules(c pcc.Client) ([]CustomRule, error) {
+	var ans []CustomRule
+	if err := c.Request(http.MethodGet, CustomRulesEndpoint, nil, nil, &ans); err != nil {
+		return nil, fmt.Errorf("error listing custom rules: %s", err)
+	}
+	return ans, nil
+}
+
+// Get a specific custom rule.
+func GetCustomRule(c pcc.Client, id int) (*CustomRule, error) {
+	rules, err := ListCustomRules(c)
+	if err != nil {
+		return nil, fmt.Errorf("error getting custom rules '%d': %s", id, err)
+	}
+	for _, val := range rules {
+		if val.Id == id {
+			return &val, nil
+		}
+	}
+	return nil, fmt.Errorf("custom rule '%s' not found", name)
+}
+
+// Create a new custom rule.
+func CreateCustomRule(c pcc.Client, rule CustomRule) error {
+	id, err := GenerateCustomRuleId(c)
+	if err != nil {
+		return nil, fmt.Errorf("error getting custom rules '%d': %s", id, err)
+	}
+	rule.Id = id
+	return UpdateCustomRule(c, rule)
+}
+
+// Helper method to generate id for new custom rule
+func GenerateCustomRuleId(c pcc.Client) (int, error) {
+	rules, err := ListCustomRules(c)
+	if err != nil {
+		return -1, fmt.Errorf("error getting custom rules: %s", err)
+	}
+	rand.Seed(time.Now().UnixNano())
+	for {
+		id := rand.Intn(100000000)
+		unique := true
+		for _, val := range rules {
+			if val.Id == id {
+				unique = false
+			}
+		}
+		if unique {
+			return id, nil
+		}
+	}
+	return -1, fmt.Errorf("error generating custom rule id")
+}
+
+// Update an existing collection.
+func UpdateCustomRule(c pcc.Client, rule CustomRule) error {
+	return c.Request(http.MethodPut, fmt.Sprintf("%s/%d", CustomRulesEndpoint, rule.Id), nil, rule, nil)
+}
+
+// Delete an existing collection.
+func DeleteCustomRule(c pcc.Client, id int) error {
+	return c.Request(http.MethodDelete, fmt.Sprintf("%s/%d", CustomRulesEndpoint, id), nil, nil, nil)
+}

--- a/rule/custom_rule.go
+++ b/rule/custom_rule.go
@@ -44,13 +44,13 @@ func GetCustomRule(c pcc.Client, id int) (*CustomRule, error) {
 }
 
 // Create a new custom rule.
-func CreateCustomRule(c pcc.Client, rule CustomRule) error {
+func CreateCustomRule(c pcc.Client, rule CustomRule) (int, error) {
 	id, err := GenerateCustomRuleId(c)
 	if err != nil {
-		return fmt.Errorf("error getting custom rules '%d': %s", id, err)
+		return -1, fmt.Errorf("error getting custom rules '%d': %s", id, err)
 	}
 	rule.Id = id
-	return UpdateCustomRule(c, rule)
+	return id, UpdateCustomRule(c, rule)
 }
 
 // Helper method to generate id for new custom rule


### PR DESCRIPTION
## Description

This one is a little tricky, cause Prisma Cloud Compute currently doesn't expose API endpoint to create a new custom-rule (should it be a feature request to Development team? @wfg). Instead, there is an endpoint that will either update rule, if it exists; or create the rule, if it doesn't exist. So, I had to add a method to generate an new random id to get around the limitation of Prisma Cloud API. The logic is decoupled in the method called `GenerateCustomRuleId`.

## Motivation and Context

It is currently blocking https://github.com/PaloAltoNetworks/terraform-provider-prismacloudcompute/issues/29

## How Has This Been Tested?

It was testing in the Terraform provider

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
